### PR TITLE
Runlist feature -- Merry Christmas!

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,19 +19,23 @@ For a list of commands:
 knife cleanup --help
 ```
 
-Currently there is only one command available:
+Options:
 
 ```bash
-knife cleanup versions <-D>
+knife cleanup versions <-D|--delete> <-B|--backup> <-R|--runlist cookbook|role>
 ```
 
-If you run it without --delete (-D) it will show you the versions that would be deleted, but not delete anything. In delete mode it will save first a backup of the version and then proceed to delete it. I've seen various strange situations where knife is not able to download the cookbook version from the server, and be aware that we will skip those cases and there will not be a backup for such corrupted versions. You've been warned. 
+When run without the `-D` option, it will show you the versions that would be deleted, but not delete anything. The default mode only looks for cookbooks that are latest, or are explicitly pinned in an environment. With a `--runlist` option, it will obtain the cookbook versions associated with that run list in each environment. This is useful when, for example, your _default environment has java pinned at '< 1.16.0', and your unpinned environments are using java 1.15.5, and you happen to have a java 1.16.0 version in the server.
+
+The delete mode will not make backup of the version unless you use the '-B|--backup' option.
+
+With the backup option, I've seen various strange situations where knife is not able to download the cookbook version from the server, and be aware that we will skip those cases and there will not be a backup for such corrupted versions. You've been warned. 
 
 Note: this is by no means production ready; I'm using it with success for my needs and hopefully you will find it useful too. Be sure to do a backup your chef server ([knife-backup][knifebackup] before using it, etc. 
 
 ## Todo/Ideas
   
-  * Make backup optional and location of them configurable
+  * Make backup location configurable
   * Cleanup databags
   * Cleanup unused cookbooks
 

--- a/lib/chef/knife/cleanup_versions.rb
+++ b/lib/chef/knife/cleanup_versions.rb
@@ -81,10 +81,10 @@ module ServerCleanup
           print "In runlist for env: #{env_list}\n"
           runlist = { "run_list"  => [ config[:runlist] ] }
           run_cookbooks = \
-             rest.put_rest("/environments/#{env_list}/cookbook_versions", runlist)
-          run_cookbook.each_key do |cb|
-            print "  purge #{cb.name}:#{cb.version} ... "
-            purged = cbv[cb.name].delete(cb.version)
+             rest.post_rest("/environments/#{env_list}/cookbook_versions", runlist)
+          run_cookbooks.each_key do |cb|
+            print "  purge #{run_cookbooks[cb].name}:#{run_cookbooks[cb].version} ... "
+            purged = cbv[run_cookbooks[cb].name].delete(run_cookbooks[cb].version)
             print purged.nil? ? "nil" : purged, "\n"
           end
         end

--- a/lib/knife-cleanup/version.rb
+++ b/lib/knife-cleanup/version.rb
@@ -1,5 +1,5 @@
 module Knife
   module Cleanup
-    VERSION = "0.0.5"
+    VERSION = "0.0.6"
   end
 end


### PR DESCRIPTION
I added this feature because the current behavior would delete cookbooks that are constrained by cookbook metadata, instead of being pinned by environment. 

```
Here's an example of the diffs between the default behavior and the new behavior:

```

diff -U0 OLDversion NEWversion
--- OLDversion  2013-12-24 15:30:56.000000000 -0500
+++ NEWversion  2013-12-24 18:54:45.000000000 -0500
@@ -50,2 +50,2 @@
-     1 rsyslog                 1.6.0
-     2 runit                   1.3.0 1.2.0
-     0 rsyslog
-     1 runit                   1.2.0
  @@ -64 +64 @@
-     6 yum                     2.4.3 2.4.2 2.4.0 2.3.4 2.3.2 2.3.0
-     5 yum                     2.4.3 2.4.2 2.4.0 2.3.2 2.3.0

```

This shows that, for example, the old code would have marked yum:2.3.4 for deletion, but's it's expected by $work-mongodb, which has depends `yum ~>2.3.0` in its metadata.

Likewise, the new version saves rsyslog:1.6.0, which is specified in $work-common `rsyslog ~> 1.6.0`

I think this makes it far less likely to delete cookbooks that are, in fact, still expected by chef.
```
