### PR TITLE
fix typo for cookbooks in output string

### DIFF
--- a/lib/chef/knife/cleanup_versions.rb
+++ b/lib/chef/knife/cleanup_versions.rb
@@ -45,7 +45,7 @@ module ServerCleanup
     end
 
     def cookbooks
-      ui.msg "Searching for unused cookboks versions..."
+      ui.msg "Searching for unused cookbook versions..."
       all_cookbooks = rest.get_rest("/cookbooks?num_versions=all")
       latest_cookbooks = rest.get_rest("/cookbooks?latest")
       


### PR DESCRIPTION
@mdxp I spotted this while running `knife cleanup versions`.

Thanks for the super-handy tool!
